### PR TITLE
Extra tip for Windows RT

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ The cube responds with a packet in the following format:
 > [!TIP]
 > Immediately after connecting to the cube, you need to write a [Cube Info (0xA1)](#cube-info-0xa1) message to initialize correctly the cube.
 
+> [!TIP]
+> If you develop on Windows RT (BLE), you need to manually enable notification on the read characteristic (eg : 0783b03e-7735-b5a0-1760-a305d2795cb1) in order to receive events (unlike GANi3 which is in Notify state by default).
+> Note that this is on top of the cube info message above, both are required in that case.
+> C# example below
+> readCharacteristic.WriteClientCharacteristicConfigurationDescriptorAsync(GattClientCharacteristicConfigurationDescriptorValue.Notify);
+
 ## Cube Status (Facelet State) (0xA3)
 
 A request can be made for cube status (current facelet state) by sending a packet with **message type** `0xA3` and no data:

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ The cube responds with a packet in the following format:
 > Immediately after connecting to the cube, you need to write a [Cube Info (0xA1)](#cube-info-0xa1) message to initialize correctly the cube.
 
 > [!TIP]
-> If you develop on Windows RT (BLE), you need to manually enable notification on the read characteristic (eg : 0783b03e-7735-b5a0-1760-a305d2795cb1) in order to receive events (unlike GANi3 which is in Notify state by default).
+> If you develop on Windows RT (BLE), you need to manually enable notification on the read characteristic (eg : `0783b03e-7735-b5a0-1760-a305d2795cb1`) in order to receive events (unlike GANi3 which is in Notify state by default).
 > Note that this is on top of the cube info message above, both are required in that case.
-> C# example below
-> readCharacteristic.WriteClientCharacteristicConfigurationDescriptorAsync(GattClientCharacteristicConfigurationDescriptorValue.Notify);
+> C# example below :
+
+`readCharacteristic.WriteClientCharacteristicConfigurationDescriptorAsync(GattClientCharacteristicConfigurationDescriptorValue.Notify);`
 
 ## Cube Status (Facelet State) (0xA3)
 


### PR DESCRIPTION
Hello,
while implementing it on my Windows cube App (WinRT BLE stack) , I noticed that notify was required on top of requesting hardware info in order to receive notifications.

In case of Gan this is not required, they are directly set in that state.

So I thought I would share the tip in case someone runs into the same issue as me.

Thanks
Julien